### PR TITLE
fix text error and ensure compatibility with https

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "IvoryTower Checker",
 	"short_name": "IT Check",
-	"author": "Cody Jung, Eric Clymer",
+	"author": "Cody Jung, Eric Clymer, Andrew Herold",
 	"version": "1.4.4",
 	"description": "Checks IvoryTower for unread threads, adds misc other functionality.",
 	"icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"name": "IvoryTower Checker",
 	"short_name": "IT Check",
 	"author": "Cody Jung, Eric Clymer",
-	"version": "1.4.2",
+	"version": "1.4.4",
 	"description": "Checks IvoryTower for unread threads, adds misc other functionality.",
 	"icons": {
 		"48": "/assets/icon48.png",

--- a/manifest.json
+++ b/manifest.json
@@ -29,7 +29,7 @@
 	},
 	"content_scripts": [
 		{
-		  "matches": ["http://*.ivorytower.com/*"],
+		  "matches": ["https://*.ivorytower.com/*"],
 		  "js": [
 			  "/lib/jquery-2.1.3.min.js",
 			  "/scripts/core.js",

--- a/scripts/core.js
+++ b/scripts/core.js
@@ -28,7 +28,7 @@
 			} else {
 				isLoggedIn = true;
 				setBadgeBackgroundColor([0, 0, 255, 255]);
-				ITCheck.setTitle((unreadCount == "" ? "No " : unreadCount) + " unread threads");
+				ITCheck.setTitle((unreadCount == "" ? "No" : unreadCount) + " unread threads");
 			}	
 			setBadgeText(unreadCount);
 		},


### PR DESCRIPTION
when highlighted with the cursor, the alt text for the extension displayed "no  unread threads" (with an extra space) when no threads were present. this *should* fix that issue. a TODO is to change "threads" to "thread" when only one thread is unread for alt text.

change content_scripts URL from 'http' to 'https' - forgot in original update, ensure compatibility with IT in case 'http' stops working. 

update version number - manifest.json hadn't been updated on my last commit, however it was updated to 1.4.3 when the extension was pushed to Google. this is to reflect those changes, and new ones as well.