### PR TITLE
fixed incompatibility with new IT version 2.4.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"name": "IvoryTower Checker",
 	"short_name": "IT Check",
 	"author": "Cody Jung, Eric Clymer, Andrew Herold",
-	"version": "1.4.4",
+	"version": "1.4.5",
 	"description": "Checks IvoryTower for unread threads, adds misc other functionality.",
 	"icons": {
 		"48": "/assets/icon48.png",

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
 	"permissions": [
 		"alarms",
 		"webNavigation",
-		"https://ivorytower.com/",
+		"https://www.ivorytower.com/",
 		"storage"
 	],
 	"options_page": "/options/options.html",

--- a/scripts/core.js
+++ b/scripts/core.js
@@ -2,7 +2,7 @@
 	//window.ITCheck = window.ITCheck || {};
 	
 	var ITCheck = {
-		baseUrl: "https://ivorytower.com/IvoryTower/",
+		baseUrl: "https://www.ivorytower.com/IvoryTower/",
 		getUnreadThreadCount: function(alarm) {
 			if(ITCheck.shouldSkipRequest()) return;
 			


### PR DESCRIPTION
IT has been recently been updated to 2.4.1, changing how the SSL setup works. 

this PR fixes incompatibility with the new update, making the extension work again